### PR TITLE
Fixed `sharedAPI` resulting in nil after init with `sharedAPIWithKey`

### DIFF
--- a/KISSMetricsAPI.m
+++ b/KISSMetricsAPI.m
@@ -82,13 +82,12 @@ static KISSMetricsAPI *sharedAPI = nil;
 
 + (KISSMetricsAPI *)sharedAPIWithKey:(NSString *)apiKey
 {
-    static KISSMetricsAPI *sharedInstance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        sharedInstance = [[KISSMetricsAPI alloc] init];
+        sharedAPI = [[KISSMetricsAPI alloc] init];
         [sharedAPI initializeAPIWithKey:apiKey];
     });
-    return sharedInstance;
+    return sharedAPI;
 }
 
 


### PR DESCRIPTION
`sharedAPI` would be nil even after `sharedAPIWithKey` being called. Used `sharedAPI` in singleton instance method.
